### PR TITLE
Update devcontainer image to Python 3.10 and modify gitignore patterns

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Python 3",
-  "image": "mcr.microsoft.com/devcontainers/python:0-3.9",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers-contrib/features/ansible:2": {},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: '30 5 23 * *'
 
 jobs:
   ansible-role-ci:

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 ## Python
 .pytest_cache/
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
+pytestdebug.log

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,38 +13,59 @@ lint: |
   flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 platforms:
   - name: debian-10
-    image: "ghcr.io/hspaans/molecule-container-debian:10"
+    image: "ghcr.io/hspaans/molecule-containers:debian-10"
     command: ""
     cgroupns_mode: host
-    tmpfs:
-      - /run
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+
   - name: debian-11
-    image: "ghcr.io/hspaans/molecule-container-debian:11"
+    image: "ghcr.io/hspaans/molecule-containers:debian-11"
     command: ""
     cgroupns_mode: host
-    tmpfs:
-      - /run
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+
   - name: debian-12
-    image: "ghcr.io/hspaans/molecule-container-debian:12"
+    image: "ghcr.io/hspaans/molecule-containers:debian-12"
     command: ""
     cgroupns_mode: host
-    tmpfs:
-      - /run
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+
+  - name: ubuntu-20.04
+    image: "ghcr.io/hspaans/molecule-containers:ubuntu-20.04"
+    command: ""
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+
+  - name: ubuntu-22.04
+    image: "ghcr.io/hspaans/molecule-containers:ubuntu-22.04"
+    command: ""
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+
+  - name: ubuntu-24.04
+    image: "ghcr.io/hspaans/molecule-containers:ubuntu-24.04"
+    command: ""
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -39,33 +39,6 @@ platforms:
     privileged: true
     pre_build_image: true
 
-  - name: ubuntu-20.04
-    image: "ghcr.io/hspaans/molecule-containers:ubuntu-20.04"
-    command: ""
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
-    pre_build_image: true
-
-  - name: ubuntu-22.04
-    image: "ghcr.io/hspaans/molecule-containers:ubuntu-22.04"
-    command: ""
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
-    pre_build_image: true
-
-  - name: ubuntu-24.04
-    image: "ghcr.io/hspaans/molecule-containers:ubuntu-24.04"
-    command: ""
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
-    pre_build_image: true
-
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,15 +12,6 @@ lint: |
   # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
   flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 platforms:
-  - name: debian-10
-    image: "ghcr.io/hspaans/molecule-containers:debian-10"
-    command: ""
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
-    pre_build_image: true
-
   - name: debian-11
     image: "ghcr.io/hspaans/molecule-containers:debian-11"
     command: ""


### PR DESCRIPTION
This pull request updates the devcontainer image to Python 3.10 and modifies the gitignore patterns. It also updates the platforms in molecule.yml to use the latest versions of Debian (10, 11, and 12).